### PR TITLE
migrations for email subject and email body

### DIFF
--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -6,6 +6,8 @@
 #
 #  id                  :bigint           not null, primary key
 #  description         :text
+#  email_body          :text
+#  email_subject       :string
 #  price_cents         :integer          default(0), not null
 #  price_currency      :string           default("USD"), not null
 #  registration_ticket :boolean          default(FALSE)

--- a/db/migrate/20230323200402_add_email_subject_to_tickets.rb
+++ b/db/migrate/20230323200402_add_email_subject_to_tickets.rb
@@ -1,0 +1,5 @@
+class AddEmailSubjectToTickets < ActiveRecord::Migration[7.0]
+  def change
+    add_column :tickets, :email_subject, :string
+  end
+end

--- a/db/migrate/20230323200709_add_email_body_to_tickets.rb
+++ b/db/migrate/20230323200709_add_email_body_to_tickets.rb
@@ -1,0 +1,5 @@
+class AddEmailBodyToTickets < ActiveRecord::Migration[7.0]
+  def change
+    add_column :tickets, :email_body, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_04_26_082022) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_23_200709) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "plpgsql"
@@ -550,6 +550,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_04_26_082022) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.boolean "visible", default: true
+    t.string "email_subject"
+    t.text "email_body"
   end
 
   create_table "tracks", force: :cascade do |t|

--- a/spec/factories/tickets.rb
+++ b/spec/factories/tickets.rb
@@ -6,6 +6,8 @@
 #
 #  id                  :bigint           not null, primary key
 #  description         :text
+#  email_body          :text
+#  email_subject       :string
 #  price_cents         :integer          default(0), not null
 #  price_currency      :string           default("USD"), not null
 #  registration_ticket :boolean          default(FALSE)

--- a/spec/models/ticket_spec.rb
+++ b/spec/models/ticket_spec.rb
@@ -6,6 +6,8 @@
 #
 #  id                  :bigint           not null, primary key
 #  description         :text
+#  email_body          :text
+#  email_subject       :string
 #  price_cents         :integer          default(0), not null
 #  price_currency      :string           default("USD"), not null
 #  registration_ticket :boolean          default(FALSE)


### PR DESCRIPTION
Created a migration for adding email subject as an attribute, string, to the ticket
Created a migration for adding email body as an attribute, text, to the ticket