### PR TITLE
Add jump to current event button to schedule

### DIFF
--- a/app/assets/javascripts/osem-schedule.js
+++ b/app/assets/javascripts/osem-schedule.js
@@ -80,6 +80,36 @@ $(document).ready( function() {
   $('.unscheduled-events .schedule-event-delete-button').hide();
   $('.non_schedulable .schedule-event-delete-button').hide();
 
+  $('#current-event-btn').on('click', function() {
+    var now = new Date();
+    var closestEventId = null;
+    var smallestDiff = Infinity;
+
+    $('.date-content').each(function() {
+      var eventTimeStr = $(this).data('time');
+      if (eventTimeStr) {
+        var eventTimeParts = eventTimeStr.split(':');
+        var eventMinutes = parseInt(eventTimeParts[0]) * 60 + parseInt(eventTimeParts[1]);
+        var nowMinutes = now.getHours() * 60 + now.getMinutes();
+        var diff = Math.abs(eventMinutes - nowMinutes);
+
+        if (diff < smallestDiff) {
+          smallestDiff = diff;
+          closestEventId = $(this).find('.date-title').attr('id');
+        }
+      }
+    });
+
+    if (closestEventId) {
+      //Instead of relying on hash it's probably better to scroll using javascript
+      //Since the users and click button->scroll->click again, which won't re-scroll
+      var element = document.getElementById(closestEventId);
+        if (element) {
+            element.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        }
+    }
+  });
+
   // set events as draggable
   $('.schedule-event').not('.non_schedulable').draggable({
     snap: '.schedule-room-slot',

--- a/app/assets/javascripts/osem-schedule.js
+++ b/app/assets/javascripts/osem-schedule.js
@@ -84,29 +84,28 @@ $(document).ready( function() {
     var now = new Date();
     var closestEventId = null;
     var smallestDiff = Infinity;
+    var i=0
 
-    $('.date-content').each(function() {
+    $('.event-item').each(function() {
+
       var eventTimeStr = $(this).data('time');
-      if (eventTimeStr) {
-        var eventTimeParts = eventTimeStr.split(':');
-        var eventMinutes = parseInt(eventTimeParts[0]) * 60 + parseInt(eventTimeParts[1]);
-        var nowMinutes = now.getHours() * 60 + now.getMinutes();
-        var diff = Math.abs(eventMinutes - nowMinutes);
+        
+        if (eventTimeStr) {
+            var eventTime = new Date(eventTimeStr);
+            var diff = Math.abs(eventTime - now);
 
-        if (diff < smallestDiff) {
-          smallestDiff = diff;
-          closestEventId = $(this).find('.date-title').attr('id');
+            if (diff < smallestDiff) {
+                smallestDiff = diff;
+                closestEventId = $(this).attr('class').split(' ')[1];
+            }
         }
-      }
     });
 
     if (closestEventId) {
       //Instead of relying on hash it's probably better to scroll using javascript
       //Since the users and click button->scroll->click again, which won't re-scroll
-      var element = document.getElementById(closestEventId);
-        if (element) {
-            element.scrollIntoView({ behavior: 'smooth', block: 'start' });
-        }
+      $('.highlighted').removeClass('highlighted');
+      $('.' + closestEventId).addClass('highlighted').get(0).scrollIntoView({ behavior: 'smooth', block: 'start' });
     }
   });
 

--- a/app/assets/stylesheets/osem-schedule.scss
+++ b/app/assets/stylesheets/osem-schedule.scss
@@ -185,3 +185,10 @@
 h3.event-panel-title small {
   line-height: 1.4;
 }
+
+#current-event-btn {
+  position: fixed;
+  bottom: 40px;
+  right: 40px;
+  z-index: 1000;
+}

--- a/app/views/schedules/events.html.haml
+++ b/app/views/schedules/events.html.haml
@@ -51,8 +51,8 @@
       - start_ymd = new_start_time.strftime('%Y-%m-%d')
       - unless start_ymd.eql?(date)
         .col-xs-12.col-md-12
-          .date-content{ data: { time: event_schedule.start_time.strftime('%H:%M') } }
-            %span.date-title{ id: "event-#{event_schedule.id}" }
+          .date-content
+            %span.date-title
               = inyourtz(event_schedule.start_time, @conference.timezone) do
                 = date = start_ymd
             %a.pull-right{ title: "Go up", href: "#program" }
@@ -64,7 +64,8 @@
             = time + ' ' + timezone_text(tz_object)
       .col-xs-12.col-md-11
         - cache [@program, event_schedule, event_schedule.event, current_user, event_schedule.happening_now?, '#scheduled#full#panel'] do
-          = render 'event', event: event_schedule.event, event_schedule: event_schedule
+          .event-item{ data: { time: event_schedule.start_time.iso8601 }, class: "event-#{event_schedule.event.id}" }
+            = render 'event', event: event_schedule.event, event_schedule: event_schedule
 
     / confirmed events that are not scheduled
     - if @unscheduled_events.any?
@@ -79,7 +80,7 @@
           .unscheduled-event
             - cache [@program, event, current_user, '#unscheduled#full#panel'] do
               = render 'event', event: event, event_schedule: nil
-  %button#current-event-btn.btn.btn-primary{ type: "button" }
+  %button.btn.btn-primary#current-event-btn{ type: "button" }
     Jump to Current Event
 
 :javascript

--- a/app/views/schedules/events.html.haml
+++ b/app/views/schedules/events.html.haml
@@ -51,8 +51,8 @@
       - start_ymd = new_start_time.strftime('%Y-%m-%d')
       - unless start_ymd.eql?(date)
         .col-xs-12.col-md-12
-          .date-content
-            %span.date-title{ id: start_ymd }
+          .date-content{ data: { time: event_schedule.start_time.strftime('%H:%M') } }
+            %span.date-title{ id: "event-#{event_schedule.id}" }
               = inyourtz(event_schedule.start_time, @conference.timezone) do
                 = date = start_ymd
             %a.pull-right{ title: "Go up", href: "#program" }
@@ -79,6 +79,8 @@
           .unscheduled-event
             - cache [@program, event, current_user, '#unscheduled#full#panel'] do
               = render 'event', event: event, event_schedule: nil
+  %button#current-event-btn.btn.btn-primary{ type: "button" }
+    Jump to Current Event
 
 :javascript
   $('.program-selector').on('click', function(e) {

--- a/spec/features/event_schedules_spec.rb
+++ b/spec/features/event_schedules_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+
+describe EventSchedule, js: true do
+  Timecop.return
+  let(:test_date) { Time.current }
+  let!(:conference) do
+    create(:full_conference, start_date: test_date - 1.hour, end_date: test_date + 5.days, start_hour: 0, end_hour: 24)
+  end
+  let!(:program) { conference.program }
+  let!(:selected_schedule) { create(:schedule, program: program) }
+  let!(:scheduled_event_early) do
+    program.update!(selected_schedule: selected_schedule)
+    create(:event, program: program, state: 'confirmed', abstract: '`markdown`')
+  end
+  let!(:event_schedule_early) do
+    create(:event_schedule, event: scheduled_event_early, schedule: selected_schedule,
+   start_time: test_date - 1.hours)
+  end
+  let!(:scheduled_event_mid) do
+    program.update!(selected_schedule: selected_schedule)
+    create(:event, program: program, state: 'confirmed')
+  end
+  let!(:event_schedule_mid) do
+    create(:event_schedule, event: scheduled_event_mid, schedule: selected_schedule,
+   start_time: test_date)
+  end
+  let!(:scheduled_event_late) do
+    program.update!(selected_schedule: selected_schedule)
+    create(:event, program: program, state: 'confirmed')
+  end
+  let!(:event_schedule_late) do
+    create(:event_schedule, event: scheduled_event_late, schedule: selected_schedule,
+   start_time: test_date + 1.hours)
+  end
+
+  before do
+    login_as(create(:user), scope: :user)
+    visit events_conference_schedule_path(conference_id: conference.short_title, favourites: false)
+  end
+
+  it 'jumps to the closest event' do
+    find('#current-event-btn').click
+    highlighted_element = page.find('.highlighted', visible: true, wait: 1)
+    expect(highlighted_element[:class]).to include("event-#{scheduled_event_mid.id}")
+  end
+end


### PR DESCRIPTION
### [Pivotal Tracker Link][tracker]

<!-- Complete this section filling in the link to a tracker story. -->
[tracker]: https://www.pivotaltracker.com/story/show/187391447

## What this PR does:
<!-- Complete the following sentence: -->

This PR adds a "jump to current event" button on the schedules page to scroll to the event closest to the the current time

### Include screenshots, videos, etc.
<img width="926" alt="image" src="https://github.com/snap-cloud/snapcon/assets/45834630/db7272a5-bdd9-4b61-823d-9290fe61cfe5">


#### Who authored this PR?
<!-- Tag the names of any other contributors -->


### How should this PR be tested?

* Is there a deploy we can view?
* What do the specs/features test?

I added a test that checks that the current event is correctly highlighted

* Are there edge cases to watch out for?

Since javascript is incompatible with Timecop, I had to unfreeze timecop and use the actual real life time to test this feature.

#### Are there any complications to deploying this?

<!-- Data migrations, upgrades, etc. -->

### Checklist:

- [x] Has this been deployed to a staging environment or reviewed by a customer?
- [x] Tag someone for code review (either a coach / team member)
- [x] I have renamed the branch to match PivotTracker's suggested one (necessary for BlueJay)
