### PR TITLE
187436622 commercials embed snap

### DIFF
--- a/app/controllers/admin/commercials_controller.rb
+++ b/app/controllers/admin/commercials_controller.rb
@@ -90,7 +90,9 @@ module Admin
     end
 
     def commercial_params
-      params.require(:commercial).permit(:title, :url)
+      params.require(:commercial).permit(:title, :url).tap do |params|
+        params[:url] = Commercial.generate_snap_embed(params[:url]) if params[:url]
+      end
     end
   end
 end

--- a/app/models/commercial.rb
+++ b/app/models/commercial.rb
@@ -41,6 +41,8 @@ class Commercial < ApplicationRecord
   end
 
   def self.generate_snap_embed(url)
+    return url unless url
+
     uri = URI.parse(url)
     if uri.host == 'snap.berkeley.edu' && uri.path == '/project'
       args = URI.decode_www_form(uri.query).to_h

--- a/spec/models/commercial_spec.rb
+++ b/spec/models/commercial_spec.rb
@@ -15,6 +15,7 @@
 #  commercialable_id   :integer
 #
 require 'spec_helper'
+require 'uri'
 
 describe Commercial do
   it { is_expected.to validate_presence_of(:url) }
@@ -28,5 +29,12 @@ describe Commercial do
   it 'validates url rendering' do
     commercial = build(:conference_commercial)
     expect(commercial.valid?).to be true
+  end
+
+  it 'parses snap url' do
+    url = 'https://snap.berkeley.edu/project?username=avi_shor&projectname=stamps'
+    transformed_url = Commercial.generate_snap_embed(url)
+    expected_url = 'https://snap.berkeley.edu/embed?projectname=stamps&username=avi_shor&showTitle=true&showAuthor=true&editButton=true&pauseButton=true'
+    expect(transformed_url).to eq expected_url
   end
 end

--- a/spec/models/commercial_spec.rb
+++ b/spec/models/commercial_spec.rb
@@ -15,7 +15,6 @@
 #  commercialable_id   :integer
 #
 require 'spec_helper'
-require 'uri'
 
 describe Commercial do
   it { is_expected.to validate_presence_of(:url) }


### PR DESCRIPTION
### [Pivotal Tracker Link][tracker]

<!-- Complete this section filling in the link to a tracker story. -->
https://www.pivotaltracker.com/story/show/187436622

## What this PR does:
In the commercials upload page, if a material url corresponds to a snap project, it is automatically rendered and saved as a embedded snap project instead of loading the raw website

### Include screenshots, videos, etc.
<img width="1171" alt="image" src="https://github.com/cs169/snapcon/assets/45834630/c7722056-5d63-4b0d-b038-7f831dcb9610">


#### Who authored this PR?
<!-- Tag the names of any other contributors -->


### How should this PR be tested?

* Is there a deploy we can view?
* What do the specs/features test?

I added test coverage for the model that ensures that given a valid snap project, the link is converted correctly. The existing tests check for the bad path.

* Are there edge cases to watch out for?

#### Are there any complications to deploying this?

<!-- Data migrations, upgrades, etc. -->

### Checklist:

- [x] Has this been deployed to a staging environment or reviewed by a customer?
- [x] Tag someone for code review (either a coach / team member)
- [x] I have renamed the branch to match PivotTracker's suggested one (necessary for BlueJay)
