### PR TITLE
Fix price field not loading on ticket edit page

### DIFF
--- a/app/views/admin/tickets/_form.html.haml
+++ b/app/views/admin/tickets/_form.html.haml
@@ -22,7 +22,7 @@
   = render partial: 'shared/help', locals: { id: 'accepted_help', show_event_variables: true, show_ticket_variables: true}
   .form-group
     = f.label :price
-    = f.number_field :price, class: 'form-control'
+    = f.number_field :price, class: 'form-control', value: f.object.price.to_f, step: 0.01, min: 0
   - if Ticket.where(conference: @conference).empty?
     .form-group
       = f.label :price_currency, 'Currency'


### PR DESCRIPTION
Closes #44

**Problem**
On the admin ticket edit page, the price input did not show the current ticket price (field appeared empty).

**Cause**
The form used `number_field :price`; `price` is a Money object from money-rails. Its string representation is not suitable for `<input type="number">`, so the value did not display.

**Fix**
- Set `value: f.object.price.to_f` so the field shows the numeric amount (e.g. 10.0 for $10.00).
- Added `step: 0.01` and `min: 0` for proper currency input.

**File**
- `app/views/admin/tickets/_form.html.haml`