### PR TITLE
Fix registration form not displaying validation errors

### DIFF
--- a/app/views/devise/registrations/_form_fields.html.haml
+++ b/app/views/devise/registrations/_form_fields.html.haml
@@ -1,3 +1,11 @@
+- if resource.errors.any?
+  .alert.alert-danger
+    %h4
+      = pluralize(resource.errors.count, 'error')
+      prohibited this account from being saved:
+    %ul
+      - resource.errors.full_messages.each do |message|
+        %li= message
 - unless @user.persisted?
   .form-group
     = f.label :username


### PR DESCRIPTION
## Summary

- Registration form at `/accounts/sign_up` silently fails when validation errors occur (duplicate username, password too short, password mismatch, etc.), making it appear as if the submit button does nothing
- Root cause: the Devise registration form partial (`_form_fields.html.haml`) never renders `resource.errors`, so users receive no feedback on failed registration attempts
- Added validation error rendering to the form partial, displaying clear error messages in a Bootstrap `.alert-danger` block when registration fails

Fixes #61

## Test Plan

- [ ] Navigate to `/accounts/sign_up` and submit with a password shorter than 6 characters — verify error message is displayed
- [ ] Submit with mismatched password and password confirmation — verify error message is displayed
- [ ] Submit with a username that already exists — verify error message is displayed
- [ ] Submit with valid data — verify registration succeeds normally (no regression)
- [ ] Navigate to edit profile page — verify error messages also display correctly on validation failure (same partial is shared)
