### PR TITLE
Force SSO for new sign-ups (closes #64)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -832,7 +832,7 @@ DEPENDENCIES
   whenever
 
 RUBY VERSION
-   ruby 3.3.8p144
+   ruby 3.3.10p183
 
 BUNDLED WITH
    2.5.6

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -2,6 +2,7 @@
 
 class RegistrationsController < Devise::RegistrationsController
   prepend_before_action :check_captcha, only: [:create]
+  before_action :prevent_local_signup, only: [:create]
 
   protected
 
@@ -37,5 +38,12 @@ class RegistrationsController < Devise::RegistrationsController
       resource.validate # Look for any other validation errors besides Recaptcha
       respond_with_navigational(resource) { render :new }
     end
+  end
+
+  def prevent_local_signup
+    return unless Feature.active?(:prevent_local_signups)
+
+    redirect_to new_user_registration_path,
+                alert: 'Local sign-ups are disabled. Please use Google or Snap! to create an account.'
   end
 end

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -6,8 +6,17 @@
           %h3.panel-title
             Sign Up
         .panel-body
-          = form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
-            = render partial: 'form_fields', locals: { f: f }
-
-          = render partial: 'devise/shared/openid'
+          - if Feature.active?(:prevent_local_signups)
+            %p.text-center
+              Create your account using one of the following services:
+            = render partial: 'devise/shared/sso_buttons'
+            %hr
+            %p.text-muted.text-center
+              %small
+                Already have a local account?
+                = link_to 'Sign in here', new_user_session_path
+          - else
+            = form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
+              = render partial: 'form_fields', locals: { f: f }
+            = render partial: 'devise/shared/openid'
           = render partial: 'devise/shared/help'

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -6,7 +6,20 @@
           %h3.panel-title
             Sign In
         .panel-body
-          = form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
-            = render partial: 'form_fields', locals: { f: f }
-          = render partial: 'devise/shared/openid'
+          - if Feature.active?(:prevent_local_signups)
+            = render partial: 'devise/shared/sso_buttons'
+            .row
+              .col-md-4
+                %hr
+              .col-md-4
+                %h4.text-center
+                  or sign in with password
+              .col-md-4
+                %hr
+            = form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
+              = render partial: 'form_fields', locals: { f: f }
+          - else
+            = form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
+              = render partial: 'form_fields', locals: { f: f }
+            = render partial: 'devise/shared/openid'
           = render partial: 'devise/shared/help'

--- a/app/views/devise/shared/_sso_buttons.html.haml
+++ b/app/views/devise/shared/_sso_buttons.html.haml
@@ -1,0 +1,16 @@
+- sso_providers = omniauth_configured.select { |p| [:google, :discourse].include?(p) }
+- unless sso_providers.empty?
+  .sso-buttons
+    - if sso_providers.include?(:google)
+      = link_to user_google_omniauth_authorize_path, class: 'btn btn-default btn-lg btn-block sso-btn', method: :post do
+        %i.fa-brands.fa-google
+        Sign in with Google
+    - if sso_providers.include?(:discourse)
+      = link_to user_discourse_omniauth_authorize_path, class: 'btn btn-default btn-lg btn-block sso-btn', method: :post do
+        %span
+          Sign in with Snap
+          %em> !
+      %p.text-muted.text-center
+        %small
+          If you are not currently logged into Snap! or the Snap! Forums, you will need to log in
+          twice when using your Snap! account.

--- a/app/views/devise/shared/_sso_buttons.html.haml
+++ b/app/views/devise/shared/_sso_buttons.html.haml
@@ -2,11 +2,11 @@
 - unless sso_providers.empty?
   .sso-buttons
     - if sso_providers.include?(:google)
-      = link_to user_google_omniauth_authorize_path, class: 'btn btn-default btn-lg btn-block sso-btn', method: :post do
+      = button_to user_google_omniauth_authorize_path, class: 'btn btn-default btn-lg btn-block sso-btn' do
         %i.fa-brands.fa-google
         Sign in with Google
     - if sso_providers.include?(:discourse)
-      = link_to user_discourse_omniauth_authorize_path, class: 'btn btn-default btn-lg btn-block sso-btn', method: :post do
+      = button_to user_discourse_omniauth_authorize_path, class: 'btn btn-default btn-lg btn-block sso-btn' do
         %span
           Sign in with Snap
           %em> !

--- a/config/initializers/feature.rb
+++ b/config/initializers/feature.rb
@@ -4,5 +4,6 @@ repo = Feature::Repository::SimpleRepository.new
 
 # configure features here
 repo.add_active_feature :recaptcha unless ENV['RECAPTCHA_SITE_KEY'].blank? || ENV['RECAPTCHA_SECRET_KEY'].blank?
+repo.add_active_feature :prevent_local_signups if ENV['PREVENT_NEW_LOCAL_PASSWORDS'].present?
 
 Feature.set_repository repo

--- a/dotenv.example
+++ b/dotenv.example
@@ -102,6 +102,10 @@
 # RECAPTCHA_SITE_KEY=1234
 # RECAPTCHA_SECRET_KEY=5678
 
+# Prevent new local password sign-ups (force SSO via Google/Snap!)
+# Set to any value to enable
+# PREVENT_NEW_LOCAL_PASSWORDS=true
+
 # The Conference#short_title to redirect the root URL to
 # OSEM_ROOT_CONFERENCE=osc18
 


### PR DESCRIPTION
## Summary

- Add `PREVENT_NEW_LOCAL_PASSWORDS` environment variable that controls whether local sign-ups are allowed
- When enabled, the **sign-up page** shows only Google and Snap! SSO buttons (no username/password form)
- When enabled, the **sign-in page** places SSO buttons at the top with the traditional password form below, so existing users can still log in
- Server-side guard in `RegistrationsController` prevents bypassing the UI restriction via direct POST
- No existing auth code is deleted — the local form is conditionally hidden to avoid upstream merge conflicts
- Uses the existing `Feature` toggle system (same pattern as reCAPTCHA)

## Changes

- `config/initializers/feature.rb` — register `:prevent_local_signups` feature flag
- `app/views/devise/registrations/new.html.haml` — conditionally show SSO-only sign-up
- `app/views/devise/sessions/new.html.haml` — reorder SSO above password when flag active
- `app/views/devise/shared/_sso_buttons.html.haml` — new partial for Google + Snap! buttons
- `app/controllers/registrations_controller.rb` — block local sign-up POST when flag active
- `dotenv.example` — document the new environment variable

## Test plan

- [ ] Set `PREVENT_NEW_LOCAL_PASSWORDS=true` and verify sign-up page shows only SSO buttons
- [ ] Verify sign-in page shows SSO buttons above the password form
- [ ] Verify direct POST to /accounts is rejected with redirect
- [ ] Without the env var, verify both pages behave exactly as before

Closes #64
