### PR TITLE
Hide code of conduct link when none is set

### DIFF
--- a/app/views/conference_registrations/_registration_info.html.haml
+++ b/app/views/conference_registrations/_registration_info.html.haml
@@ -32,4 +32,5 @@
           (Scheduled on: #{event.time.to_date})
     %br
 
-= render 'conferences/code_of_conduct', organization: @conference.organization
+- unless @conference.code_of_conduct.blank?
+  = render 'conferences/code_of_conduct', organization: @conference.organization

--- a/spec/controllers/conference_registration_controller_spec.rb
+++ b/spec/controllers/conference_registration_controller_spec.rb
@@ -307,16 +307,47 @@ max_attendees: 5, state: 'confirmed')
     describe 'GET #edit' do
       before do
         @registration = create(:registration, conference: conference, user: user)
-        get :edit, params: { conference_id: conference.short_title }
       end
 
-      it 'assigns conference and registration variable' do
-        expect(assigns(:conference)).to eq conference
-        expect(assigns(:registration)).to eq @registration
+      context 'basic request' do
+        before do
+          get :edit, params: { conference_id: conference.short_title }
+        end
+
+        it 'assigns conference and registration variable' do
+          expect(assigns(:conference)).to eq conference
+          expect(assigns(:registration)).to eq @registration
+        end
+
+        it 'renders the edit template' do
+          expect(response).to render_template('edit')
+        end
       end
 
-      it 'renders the edit template' do
-        expect(response).to render_template('edit')
+      context 'code of conduct visibility' do
+        render_views
+
+        context 'conference has no code of conduct' do
+          before do
+            conference.organization.update(code_of_conduct: nil)
+            get :edit, params: { conference_id: conference.short_title }
+          end
+
+          it 'does not render the code of conduct modal' do
+            expect(response.body).not_to include('modal-code-of-conduct')
+          end
+        end
+
+        context 'conference has a code of conduct' do
+          before do
+            conference.organization.update(code_of_conduct: 'Be nice to each other.')
+            get :edit, params: { conference_id: conference.short_title }
+          end
+
+          it 'renders the code of conduct modal' do
+            expect(response.body).to include('modal-code-of-conduct')
+          end
+        end
       end
     end
 


### PR DESCRIPTION
**What this PR does:**

  - Fixes the registration form (new/edit) rendering an empty code of conduct modal and nav link when no code of conduct is set on the organization. Adds the same `unless @conference.code_of_conduct.blank?` guard that every other callsite already uses.

  Related upstream issue: https://github.com/snap-cloud/snapcon/issues/211

**Include screenshots, videos, etc.**

  - N/A: one-line view fix, no UI additions.

**Who authored this PR?**
  @sikesbc

**How should this PR be tested?**

  - Find a conference whose organization has no code of conduct set.
  - Visit the new or edit registration page for that conference.
  - Confirm there is no "Code of Conduct" modal or nav link on the page.
  - Set a code of conduct on the organization and revisit — confirm the modal and link now appear.
  - New specs in spec/controllers/conference_registration_controller_spec.rb cover both cases.

**Are there any complications to deploying this?**

  - No migrations or data changes, just a guard clause in a view partial.