### PR TITLE
Remove organization grouping from conference menu

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -211,6 +211,6 @@ hint: options[:hint]
 
   def visible_conference_links
     @visible_conference_links ||=
-      Conference.all.select(:id, :organization_id, :title, :short_title, :start_date).includes(:splashpage, :organization).select { |conf| can?(:show, conf) }.group_by(&:organization)
+      Conference.all.select(:id, :title, :short_title, :start_date).includes(:splashpage).select { |conf| can?(:show, conf) }.sort_by(&:start_date).reverse
   end
 end

--- a/app/views/layouts/_snapcon_nav.haml
+++ b/app/views/layouts/_snapcon_nav.haml
@@ -9,9 +9,5 @@
     All Events
     %b.caret
   %ul.dropdown-menu
-    - visible_conference_links.each_with_index do |(org, confs), index|
-      %li.dropdown-header= org.name
-      - confs.sort_by(&:start_date).each do |conf|
-        %li= link_to(conf.title, conference_path(conf.short_title))
-      - if index < visible_conference_links.length - 1
-        %li.divider
+    - visible_conference_links.each do |conf|
+      %li= link_to(conf.title, conference_path(conf.short_title))

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -156,6 +156,26 @@ start_time: conference.start_date + conference.start_hour.hours, room: create(:r
     end
   end
 
+  describe '#visible_conference_links' do
+    before do
+      conference # force creation
+      allow_any_instance_of(ApplicationHelper).to receive(:can?).and_return(true)
+    end
+
+    it 'returns conferences sorted by start date descending' do
+      confs = visible_conference_links
+      expect(confs).to eq confs.sort_by { |c| c.start_date }.reverse
+    end
+
+    it 'does not group by organization' do
+      expect(visible_conference_links).to be_an(Array)
+    end
+
+    it 'includes visible conferences' do
+      expect(visible_conference_links).to include(conference)
+    end
+  end
+
   describe '#event_type_sentence' do
     before do
       create(:event_type, title: 'Keynote', program: conference.program, enable_public_submission: false)


### PR DESCRIPTION
**What this PR does:**

  - Removes the organization-based grouping from the "All Events" dropdown menu in the navbar. Conferences are now listed as a flat list sorted by start date (newest first). Also removes the unnecessary eager-loading of organizations on every page.

  Related upstream issues: https://github.com/snap-cloud/snapcon/issues/408 https://github.com/snap-cloud/snapcon/issues/312

**Include screenshots, videos, etc.**

  - N/A: nav menu change, visually simpler (no org headers or dividers).

**Who authored this PR?**
  @sikesbc

**How should this PR be tested?**

  - Visit any page and open the "All Events" dropdown in the navbar.
  - Confirm conferences are listed newest first without organization headers or dividers.
  - New specs in spec/helpers/application_helper_spec.rb verify the helper returns a flat array sorted by date.

**Are there any complications to deploying this?**

  - No migrations or data changes. The organization_id column still exists on conferences, we just no longer use it for the menu grouping.